### PR TITLE
Also clear AreaDescription text OnIconLeave

### DIFF
--- a/Telemancy.lua
+++ b/Telemancy.lua
@@ -112,6 +112,7 @@ end
 
 t.OnIconLeave = function(self)
 	WorldMapFrameAreaLabel:SetText("");
+	WorldMapFrameAreaDescription:SetText("");
 end
 
 t.Setup = function()


### PR DESCRIPTION
Fixes an issue where the "Status: XXXX" text stays on the map.

