### PR TITLE
Fix icons disappearing from Large World Map

### DIFF
--- a/Telemancy.lua
+++ b/Telemancy.lua
@@ -95,7 +95,7 @@ t.OnIconUpdate = function(self, elapsed)
 	if self.updateTimer >= 1 then
 		-- Get the current width/height of the POI frame.
 		local frameWidth, frameHeight = WorldMapPOIFrame:GetSize();
-		self:SetFrameStrata("HIGH"); -- Map frame resets strata, so we enforce it here every time.
+		self:SetFrameStrata("TOOLTIP"); -- Map frame resets strata, so we enforce it here every time.
 		self:SetPoint("TOPLEFT", (frameWidth * self.teleX) - ICON_OFFSET, (frameHeight * self.teleY) + ICON_OFFSET);
 
 		t.UpdateIconState(self);


### PR DESCRIPTION
Frame strata layer has to be **"FULLSCREEN"** or higher for the icons to remain visible on the Large World Map.

I just set it to **"TOOLTIP"** again since that's what it's initially created as. (and it's also the highest layer)